### PR TITLE
Corrected cron job lines in Boxfile

### DIFF
--- a/Boxfile
+++ b/Boxfile
@@ -8,5 +8,5 @@ web1:
     - mysql
     - curl
   cron:
-    - 0 0 * * *  scripts/mysql_dump.sh
-    - 10 0 * * *  php scripts/s3.php backup-bucket backups/db_backup
+    - "0 0 * * *":  "scripts/mysql_dump.sh"
+    - "10 0 * * *":  "php scripts/s3.php backup-bucket backups/db_backup"


### PR DESCRIPTION
The cron job lines in the Boxfile require quotes around the date/time and command, and a colon between them.
http://help.pagodabox.com/customer/portal/articles/333772#cron_boxfile
